### PR TITLE
Add option for slave switches to be protected from misunderstood Siri commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@
           "accessory": "OccupancyDelay",
           "name": "OccupancyDelay",
           "delay": 5,
-          "slaveCount": 1
+          "slaveCount": 1,
+          "protected": false
         }   
     ]
 ```
 
-Note, "delay" is in seconds.
+Note: "delay" is in seconds. If "protected" is set to true, the slave switches will be
+created using a custom boolean characteristic that can't be controlled through Siri
+(or the current Home app), but can be controlled through third party apps such as Eve:
+they can thus be protected from being controlled accidentally through a misunderstood Siri
+command.
 
 ## What problem will this solve?
 

--- a/index.js
+++ b/index.js
@@ -7,10 +7,6 @@ module.exports = function(homebridge) {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
 
-
-
-
-
   /**
    * Characteristic "Time Remaining"
    */
@@ -49,7 +45,34 @@ module.exports = function(homebridge) {
   Characteristic.TimeoutDelay.UUID = '1100006D-0000-1000-8000-0026BB765291';
 
 
+  /**
+   * Characteristic "Enabled", Bool attribute
+   */
+  Characteristic.Enabled = function () {
+    Characteristic.call(this, 'Enabled', Characteristic.Enabled.UUID)
 
+    this.setProps({
+      format: Characteristic.Formats.BOOL,
+      perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY, Characteristic.Perms.WRITE],
+    })
+  }
+  inherits(Characteristic.Enabled, Characteristic)
+  Characteristic.Enabled.UUID = '79c5cb42-4554-11ea-b071-4bf76b071f47'
+  
+
+  /**
+   * Service CustomSwitch, like switch but with an Enabled Characteristic
+   * so that can't accidentally be controlled through Siri, for instance
+   */
+  Service.CustomSwitch = function (displayName, subtype) {
+    Service.call(this, displayName, Service.CustomSwitch.UUID, subtype)
+    this.addCharacteristic(Characteristic.Enabled)
+  }
+  inherits(Service.CustomSwitch, Service)
+  Service.CustomSwitch.UUID = '0ad4aebe-4555-11ea-bf4b-f30c92b99e11'
+
+
+  // Register
   homebridge.registerAccessory("homebridge-occupancy-delay", "OccupancyDelay", OccupancyDelay);
 };
 
@@ -85,6 +108,7 @@ class OccupancyDelay {
     this.name = config.name || "OccupancyDelay";
     this.slaveCount = Math.max(1, (config.slaveCount || 1));
     this.delay = Math.min(3600, Math.max(0, parseInt(config.delay, 10) || 0));
+    this.protect = !!config.protected
 
 
     this._timer = null;
@@ -106,8 +130,6 @@ class OccupancyDelay {
 
     this.occupancyService.addCharacteristic(Characteristic.TimeRemaining);
     this.occupancyService.setCharacteristic(Characteristic.TimeRemaining, 0);
-
-
 
 
     /* Make the slave Switches */
@@ -148,7 +170,7 @@ class OccupancyDelay {
   };
 
   /**
-   * Stops teh countdown timer
+   * Stops the countdown timer
    */
   stop() {
     if (this._timer) {
@@ -170,6 +192,7 @@ class OccupancyDelay {
       this.occupancyService.setCharacteristic(Characteristic.TimeRemaining, this.delay);
     }
   }
+
 
   setOccupancyNotDetected() {
     this._last_occupied_state = false;
@@ -222,9 +245,10 @@ class OccupancyDelay {
 
 
     /* look at all the slave switches "on" characteristic and return to callback */
+    const onCharacteristic = this.protect ? Characteristic.Enabled : Characteristic.On
     for (let i = 0; i < this.slaveCount; i += 1) {
       this.switchServices[i]
-          .getCharacteristic(Characteristic.On)
+          .getCharacteristic(onCharacteristic)
           .getValue(function(err, value) {
             if (!err) {
               set_value(value);
@@ -268,9 +292,16 @@ class OccupancyDelay {
     }
 
     this.log('Create Switch: ' + displayName);
-    sw = new Service.Switch(displayName, name);
-    sw.setCharacteristic(Characteristic.On, false);
-    sw.getCharacteristic(Characteristic.On).on('change', this.checkOccupancy.bind(this));
+    
+    if (this.protect) {
+      sw = new Service.CustomSwitch(displayName, name);
+      sw.setCharacteristic(Characteristic.Enabled, false);
+      sw.getCharacteristic(Characteristic.Enabled).on('change', this.checkOccupancy.bind(this));
+    } else {
+      sw = new Service.Switch(displayName, name);
+      sw.setCharacteristic(Characteristic.On, false);
+      sw.getCharacteristic(Characteristic.On).on('change', this.checkOccupancy.bind(this));
+    }
 
     return sw;
   }


### PR DESCRIPTION
This PR adds a new option to the configuration. "protected" set to true will create the slave switches with a custom characteristic called "Enabled" instead of the default On switch. Because it's a custom characteristic, it is protected from accidental control via Siri, for instance.